### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -110,7 +110,7 @@ function updateMeta($id, $parid, $lastrev, $revert = -1) {
 
 class action_plugin_dokutranslate extends DokuWiki_Action_Plugin {
 
-	public function register(Doku_Event_Handler &$controller) {
+	public function register(Doku_Event_Handler $controller) {
 		$this->setupLocale();
 		$controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'handle_html_editform_output');
 		$controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'handle_disabled');

--- a/syntax.php
+++ b/syntax.php
@@ -169,7 +169,7 @@ class syntax_plugin_dokutranslate extends DokuWiki_Syntax_Plugin {
 		$this->Lexer->addExitPattern('~~DOKUTRANSLATE_END~~','plugin_dokutranslate');
 	}
 
-	public function handle($match, $state, $pos, &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
 		switch ($state) {
 		case DOKU_LEXER_ENTER:
 		case DOKU_LEXER_EXIT:
@@ -180,7 +180,7 @@ class syntax_plugin_dokutranslate extends DokuWiki_Syntax_Plugin {
 		return array($state, $match);
 	}
 
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		global $DOKUTRANSLATE_NEST;
 		global $ID;
 		global $ACT;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
